### PR TITLE
Add Results Visualizer app

### DIFF
--- a/Results-visualizer.ipynb
+++ b/Results-visualizer.ipynb
@@ -11,7 +11,7 @@
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
     "    return false;\n",
     "}\n",
-    "document.title='Aurora app'"
+    "document.title='Results Visualizer'"
    ]
   },
   {
@@ -35,11 +35,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a938a8c7-bff3-4df0-8ca8-1a5b56fc3aac",
+   "id": "ebb0f23e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from aurora.interface.main import MainPanel"
+    "from aurora.interface.analyze import CyclingResultsWidget"
    ]
   },
   {
@@ -49,8 +49,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "w_main = MainPanel()\n",
-    "display(w_main)"
+    "w_results = CyclingResultsWidget()\n",
+    "display(w_results)"
    ]
   },
   {

--- a/aurora/engine/results.py
+++ b/aurora/engine/results.py
@@ -1,0 +1,23 @@
+import datetime
+import aiida
+from aiida import load_profile
+from aiida.orm import Group, QueryBuilder, load_node
+import aiida_aurora.utils
+
+load_profile()
+BatteryCyclerExperiment = aiida.plugins.CalculationFactory('aurora.cycler')
+
+def query_jobs(last_days=0, group='CalcJobs'):
+    qb = QueryBuilder()
+    qb.append(Group, filters={'label': group}, tag='g')
+    qb.append(BatteryCyclerExperiment, with_group='g', tag='jobs',
+             project=['id', 'label', 'ctime', 'attributes.process_label', 'attributes.state', 'attributes.status', 'extras.monitored'])
+    if last_days:
+        qb.add_filter('jobs', {'ctime': {'>=': datetime.datetime.now() - datetime.timedelta(days=last_days)}})
+    qb.order_by({'jobs': {'ctime': 'desc'}})
+    return [q['jobs'] for q in qb.dict()]
+
+def cycling_analysis(job_id):
+    job_node = load_node(pk=job_id)
+    data = aiida_aurora.utils.cycling_analysis.cycling_analysis(job_node)
+    return data

--- a/aurora/interface/analyze/__init__.py
+++ b/aurora/interface/analyze/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from .visualizer import PreviewResults
+from .visualizer import CyclingResultsWidget

--- a/aurora/interface/analyze/visualizer.py
+++ b/aurora/interface/analyze/visualizer.py
@@ -1,48 +1,145 @@
 # -*- coding: utf-8 -*-
 
 import ipywidgets as ipw
+from aurora.engine.results import query_jobs, cycling_analysis
+import aiida_aurora.utils
+import pandas as pd
 
-
-class PreviewResults(ipw.VBox):
-    
-    BOX_LAYOUT_1 = {'width': '50%'}
-    BOX_STYLE = {'description_width': '15%'}
+class CyclingResultsWidget(ipw.VBox):
+    BOX_STYLE = {'description_width': 'initial'}
+    BOX_LAYOUT_1 = {'width': '40%'}
     BUTTON_STYLE = {'description_width': '30%'}
     BUTTON_LAYOUT = {'margin': '5px'}
-    MAIN_LAYOUT = {'width': '100%', 'padding': '10px', 'border': 'solid blue 2px'}
+    OUTPUT_LAYOUT = {'max_height': '500px', 'width': '90%', 'overflow': 'scroll', 'border': 'solid 1px', 'margin': '5px', 'padding': '5px'}
+    PLOT_TYPES = [('', ''), ('Voltage & current vs time', 'voltagecurrent_time'), ('Voltage vs time', 'voltage_time'), ('Current vs time', 'current_time'), ('Capacity vs cycle', 'capacity_cycle')]
 
     def __init__(self):
-        
-        # initialize widgets
-        self.w_header_label = ipw.HTML(value="<h2>Results Visualization</h2>")
-        self.w_select_job = ipw.Dropdown(
-            description="Select Job ID:", value=None,
-            options=['[25]  Conrad_commercial-1_cycling_20220628'],
-            layout=self.BOX_LAYOUT_1, style={'description_width': 'initial'})
 
-        with open("visualizer-example/Ewe_vs_t.png", "rb") as file:
-            self.w_plot_1 = ipw.Image(
-                value=file.read(),
-                format='png', width=400)#, height=400)
-        with open("visualizer-example/I_vs_t.png", "rb") as file:
-            self.w_plot_2 = ipw.Image(
-                value=file.read(),
-                format='png', width=400)#, height=400)
-        with open("visualizer-example/Q_vs_cn.png", "rb") as file:
-            self.w_plot_3 = ipw.Image(
-                value=file.read(),
-                format='png', width=400)#, height=400)
+        # initialize widgets
+        self.w_joblist_header = ipw.HTML(value="<h2>Job list</h2>")
+        self.w_job_days = ipw.BoundedIntText(
+            description="Last n. of days:", min=0, max=1e6, step=1,
+            value=0, style=self.BOX_STYLE)
+        self.w_update = ipw.Button(
+            description="Update",
+            button_style='', tooltip="Update list", icon='refresh',
+            style=self.BUTTON_STYLE, layout=self.BUTTON_LAYOUT)
+        self.w_joblist = ipw.Output(layout=self.OUTPUT_LAYOUT)
+
+        self.w_select_sample_id = ipw.Dropdown(
+            description="Select Battery ID:", value=None,
+            layout=self.BOX_LAYOUT_1, style={'description_width': 'initial'})
+        
+        self.w_results_header = ipw.HTML(value="<h2>Results</h2>")
+        self.w_plot_type = ipw.Dropdown(
+            description="Select plot type:", value=None,
+            options=self.PLOT_TYPES,
+            layout=self.BOX_LAYOUT_1, style={'description_width': 'initial'})
+        self.w_plot_draw = ipw.Button(
+            description="Draw plot",
+            button_style='info', tooltip="Draw plot", icon='line-chart',
+            disabled=True,
+            style=self.BUTTON_STYLE, layout=self.BUTTON_LAYOUT)
+        self.w_log_output = ipw.Output()
+        self.w_plot_output = ipw.Output()
 
         super().__init__()
         self.children = [
-            self.w_header_label,
-            self.w_select_job,
-            ipw.HBox([
-                self.w_plot_1,
-                self.w_plot_2,
-                self.w_plot_3,
-            ], layout=self.MAIN_LAYOUT),
+            self.w_joblist_header,
+            ipw.HBox([self.w_job_days, self.w_update]),
+            self.w_joblist,
+            self.w_select_sample_id,
+            self.w_results_header,
+            ipw.HBox([self.w_plot_type, self.w_plot_draw]),
+            self.w_log_output,
+            self.w_plot_output
         ]
+        
+        # initialize options
+        self.update_job_list()
+#         self._create_figure(title='')
+        
+        # setup automations
+        self.w_update.on_click(self.update_job_list)
+        self.w_select_sample_id.observe(self._load_data)
+        self.w_plot_draw.on_click(self.draw_plot)
 
-w_results = PreviewResults()
-w_results
+    def _build_job_list(self):
+        query = query_jobs(self.w_job_days.value)
+        self.job_list = pd.DataFrame(query)
+        self.job_list['ctime'] = self.job_list['ctime'].dt.strftime('%Y-%m-%d %H:%m:%S')
+        self.job_list.rename(columns={
+            'id': 'ID',
+            'label': 'Label',
+            'ctime': 'creation time',
+            'attributes.process_label': 'job type',
+            'attributes.state': 'state',
+            'attributes.status': 'reason',
+            'extras.monitored': 'monitored'
+        }, inplace=True)
+        self.job_list['monitored'] = self.job_list['monitored'].astype(bool)
+
+    @staticmethod
+    def _build_sample_id_options(table):
+        """Returns a (option_string, ID) list."""
+        return [("", None)] + [(f"<{row['ID']:5} >   {row['Label']}", row['ID']) for index, row in table.iterrows()]
+
+    def _update_sample_id_options(self):
+        """Update the specs' options."""
+#         self._unset_specs_observers()
+        self.w_select_sample_id.options = self._build_sample_id_options(self.job_list)
+#         self._set_specs_observers()
+
+    def update_job_list(self, dummy=None):
+        self._build_job_list()
+        self.w_joblist.clear_output()
+        with self.w_joblist:
+            display(self.job_list.style.hide_index())
+        self._update_sample_id_options()
+
+    @property
+    def selected_job_id(self):
+        return self.w_select_sample_id.value
+    
+    @property
+    def selected_plot_type(self):
+        return self.w_plot_type.value
+
+    def _cycling_analysis(self):
+        return cycling_analysis(self.selected_job_id)
+    
+    def _load_data(self, dummy=None):
+        "Load data, store it, and print some output info."
+        self.w_log_output.clear_output()
+        if self.selected_job_id:
+            self.w_plot_draw.disabled = False
+            with self.w_log_output:
+                # NOTE TODO: maybe we do not always want to perform a cycling analysis, loading the data would be enough
+                self.data = self._cycling_analysis()
+        else:
+            self.w_plot_draw.disabled = True
+
+        # reset plot
+        self.w_plot_type.value = None
+        self.w_plot_output.clear_output()
+
+    def draw_plot(self, dummy=None):       
+        title = None
+        if self.selected_job_id and self.selected_plot_type:
+            self.w_plot_output.clear_output()
+            with self.w_plot_output:
+                # NOTE: this is a very rudimental way of creating plots
+                # --> check the internet for the best way to work with matplotlib plots in ipywidgets
+                # e.g. https://swdevnotes.com/python/2021/interactive-charts-with-ipywidgets-matplotlib/
+                # CURRENT BUG: once created, plots cannot be deleted
+                # I think we need to implement a way to update a figure/axes
+                if not self.data:
+                    print("ERROR: No data loaded!")
+                elif self.selected_plot_type == 'voltagecurrent_time':
+                    aiida_aurora.utils.plot.plot_Ewe_I(self.data)
+                elif self.selected_plot_type == 'voltage_time':
+                    aiida_aurora.utils.plot.plot_Ewe(self.data)
+                elif self.selected_plot_type == 'current_time':
+                    aiida_aurora.utils.plot.plot_I(self.data)
+                elif self.selected_plot_type == 'capacity_cycle':
+                    aiida_aurora.utils.plot.plot_Qd(self.data)

--- a/aurora/interface/main.py
+++ b/aurora/interface/main.py
@@ -6,14 +6,13 @@ from IPython.display import display
 from .sample import SampleFromId, SampleFromSpecs, SampleFromRecipe
 from .cycling import CyclingStandard, CyclingCustom
 from .tomato import TomatoSettings
-from .analyze import PreviewResults
 from aurora.engine import submit_experiment
 
 CODE_NAME = "ketchup-0.2rc2"
 
 class MainPanel(ipw.VBox):
 
-    _ACCORDION_STEPS = ['Sample selection', 'Cycling Protocol', 'Job Settings', 'Submit Job', 'Visualize Results']
+    _ACCORDION_STEPS = ['Sample selection', 'Cycling Protocol', 'Job Settings', 'Submit Job']
     _SAMPLE_INPUT_LABELS = ['Select from ID', 'Select from Specs', 'Make from Recipe']
     _SAMPLE_INPUT_METHODS = ['id', 'specs', 'recipe']
     _METHOD_LABELS = ['Standardized', 'Customized']
@@ -164,8 +163,9 @@ class MainPanel(ipw.VBox):
                     self.w_submit_button.disabled = False
                     print(f"✅ All good!")
     
-    @w_submission_output.capture(clear_output=True, wait=True)
+    @w_submission_output.capture()
     def submit_job(self, dummy=None):
+        self.w_submit_button.disabed = True
         self.process = submit_experiment(
             sample=self.selected_battery_sample,
             method=self.selected_cycling_protocol,
@@ -176,9 +176,7 @@ class MainPanel(ipw.VBox):
             method_node_label="",
             calcjob_node_label=""
         )
-        print(f"Job <{self.process.pk}> submitted to AiiDA...")
-
-        self.w_main_accordion.selected_index = 4
+        self.w_main_accordion.selected_index = None
 
     #######################################################################################
     # RESET
@@ -204,6 +202,7 @@ class MainPanel(ipw.VBox):
         "Reset the interface."
         # TODO: properly reinitialize each widget
         self.reset_all_inputs()
+        self.w_submission_output.clear_output()
         self.w_main_accordion.selected_index = 0
 
     #######################################################################################
@@ -260,12 +259,8 @@ class MainPanel(ipw.VBox):
         self.w_submit_tab = ipw.VBox([
             self.w_job_preview,
             self.w_code,
-            self.w_submit_button,
-            self.w_submission_output
+            self.w_submit_button
         ])
-
-        # Results
-        self.w_results_tab = PreviewResults()
 
         # Reset
         self.w_reset_button = ipw.Button(
@@ -280,7 +275,6 @@ class MainPanel(ipw.VBox):
             self.w_test_tab,
             self.w_settings_tab,
             self.w_submit_tab,
-            self.w_results_tab
         ])
         for i, title in enumerate(self._ACCORDION_STEPS):
             self.w_main_accordion.set_title(i, title)
@@ -290,6 +284,7 @@ class MainPanel(ipw.VBox):
             self.w_header,
             self.w_main_accordion,
             self.w_reset_button,
+            self.w_submission_output
         ]
 
         # setup automations

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ title = Aurora
 
 [metadata]
 name = aurora
-version = 0.3.0
+version = 0.4.0
 author = Loris Ercole
 author_email = loris.ercole@epfl.ch
 description = An AiiDAlab application for the Aurora BIG-MAP Stakeholder initiative.
@@ -28,7 +28,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     aiidalab>=21.09.0
-    aiida-aurora>=0.3.0
+    aiida-aurora>=0.3.1
     dgbowl-schemas>=111
     ipywidgets
     ipympl

--- a/start.py
+++ b/start.py
@@ -3,7 +3,8 @@
 import ipywidgets as ipw
 
 template = """
-<h1><a title="Launch Aurora app" href="{appbase}/Aurora-app.ipynb" target="_blank">Aurora app</a></h1>
+<h1>&clubs; <a title="Launch Aurora app" href="{appbase}/Aurora-app.ipynb" target="_blank">Aurora app</a></h1>
+<h2>&clubs; <a title="Visualize Results" href="{appbase}/Results-visualizer.ipynb" target="_blank">Results visualizer</a></h2>
 """
 
 


### PR DESCRIPTION
Closes #15 
@ramirezfranciscof
"Aurora app" now implements only submit functions. 
I implemented the "Results Visualizer", containing some basic functionalities to show the list of submitted jobs (monitored jobs are not visualized, for simplicity). The user can select a job and visualize the results. For now, only these plots are implemented:
- voltage vs time
- current vs time
- voltage & current vs time
- capacity vs cycle number
If a job is monitored, the results from the monitor node will be retrieved.
If a job is still running (monitored), the last snapshot will be used.
If a job does not have a results output node, for any reason, we will try to retrieve/read the raw data either from the monitor or the calcjob node (see https://github.com/epfl-theos/aiida-aurora/blob/23811bc02e59e8c01e7cf449ff5fa0d5f27db666/aiida_aurora/utils/cycling_analysis.py#L102-L108 )

This PR needs `aiida-aurora>=0.3.1`.

BUG - TODO: a new matplotlib figure is generated every time the plot button is clicked and the figure is appended. Ideally one should update the same figure. Moreover, I was not able to clear the output once generated, not sure why.