### PR TITLE
Add CI pipeline on push/PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pre-commit~=2.2
+          # TODO! change `pre-commit~=2.2` to `.[devtools]`
+          # ! once aiida-aurora dependency issue is resolved
+
+      - name: Run pre-commit hooks
+        run: |
+          pre-commit install
+          pre-commit run --all-files


### PR DESCRIPTION
Added a github actions workflow to install and run the pre-commit script on push and PRs.

NOTE: the workflow should ideally install pre-commit as part of installing the app, i.e. `pip install .[devtools]`. However, at the moment, the dependency on aiida-aurora>=0.3.1 is incompatible, as 0.3.1 is yet to be released.