### PR TITLE
Fixing previously bypasses `mypy` errors

### DIFF
--- a/aurora/schemas/cycling.py
+++ b/aurora/schemas/cycling.py
@@ -66,8 +66,7 @@ allowed_E_ranges = Literal["+-2.5 V", "+-5.0 V", "+-10 V", "auto", ]
 ################################################################################
 
 
-class DummySequential(CyclingTechnique,
-                      extra=Extra.forbid):  # type: ignore[call-arg]
+class DummySequential(CyclingTechnique):
     device: Literal["worker"] = "worker"
     technique: Literal["sequential"] = "sequential"
     short_name: Literal["DUMMY_SEQUENTIAL"] = "DUMMY_SEQUENTIAL"
@@ -102,8 +101,7 @@ class DummySequential(CyclingTechnique,
 
 
 ################################################################################
-class DummyRandom(CyclingTechnique,
-                  extra=Extra.forbid):  # type: ignore[call-arg]
+class DummyRandom(CyclingTechnique):
     device: Literal["worker"] = "worker"
     technique: Literal["random"] = "random"
     short_name: Literal["DUMMY_RANDOM"] = "DUMMY_RANDOM"
@@ -138,8 +136,7 @@ class DummyRandom(CyclingTechnique,
 
 
 ################################################################################
-class OpenCircuitVoltage(CyclingTechnique,
-                         extra=Extra.forbid):  # type: ignore[call-arg]
+class OpenCircuitVoltage(CyclingTechnique):
     device: Literal["MPG2"] = "MPG2"
     technique: Literal["open_circuit_voltage"] = "open_circuit_voltage"
     short_name: Literal["OCV"] = "OCV"
@@ -206,8 +203,7 @@ class OpenCircuitVoltage(CyclingTechnique,
 
 
 ################################################################################
-class ConstantVoltage(CyclingTechnique,
-                      extra=Extra.forbid):  # type: ignore[call-arg]
+class ConstantVoltage(CyclingTechnique):
     device: Literal["MPG2"] = "MPG2"
     technique: Literal["constant_voltage"] = "constant_voltage"
     short_name: Literal["CV"] = "CV"
@@ -336,8 +332,7 @@ class ConstantVoltage(CyclingTechnique,
 
 
 ################################################################################
-class ConstantCurrent(CyclingTechnique,
-                      extra=Extra.forbid):  # type: ignore[call-arg]
+class ConstantCurrent(CyclingTechnique):
     device: Literal["MPG2"] = "MPG2"
     technique: Literal["constant_current"] = "constant_current"
     short_name: Literal["CC"] = "CC"
@@ -466,14 +461,14 @@ class ConstantCurrent(CyclingTechnique,
 
 
 ################################################################################
-# class SweepVoltage(CyclingTechnique, extra=Extra.forbid):  # type: ignore[call-arg]
+# class SweepVoltage(CyclingTechnique):
 #    technique: Literal["sweep_voltage"] = "sweep_voltage"
 #    short_name: Literal["LSV"] = "LSV"
 #    name = "LSV"
 #    description = "Controlled voltage technique, allowing linear change of voltage between pre-defined endpoints as a function of time, with optional current and voltage limits"
 
 ################################################################################
-# class SweepCurrent(CyclingTechnique, extra=Extra.forbid):  # type: ignore[call-arg]
+# class SweepCurrent(CyclingTechnique):
 #    technique: Literal["sweep_current"] = "sweep_current"
 #    short_name: Literal["LSC"] = "LSC"
 #    name = ""
@@ -481,7 +476,7 @@ class ConstantCurrent(CyclingTechnique,
 
 
 ################################################################################
-class Loop(CyclingTechnique, extra=Extra.forbid):  # type: ignore[call-arg]
+class Loop(CyclingTechnique):
     device: Literal["MPG2"] = "MPG2"
     technique: Literal["loop"] = "loop"
     short_name: Literal["LOOP"] = "LOOP"

--- a/aurora/schemas/cycling.py
+++ b/aurora/schemas/cycling.py
@@ -16,7 +16,8 @@ I also need to add items and __getitem__ because some other parts of the code
 expect it to behave like a dict...
 """
 
-from typing import Dict, Generic, Literal, Sequence, TypeVar, Union, get_args
+from typing import (Dict, Generic, Literal, Optional, Sequence, TypeVar, Union,
+                    get_args)
 
 from pydantic import BaseModel, Extra, NonNegativeFloat, NonNegativeInt
 from pydantic.generics import GenericModel
@@ -29,8 +30,8 @@ class CyclingParameter(GenericModel, Generic[DataT]):
     label: str  # the label used in a widget
     description: str = ""  # a long description
     units: str = ""  # physical units of this parameter
-    value: DataT = None  # type: ignore[assignment] # the set value
-    default_value: DataT = None  # type: ignore[assignment] # the default value of this parameter
+    value: Optional[DataT] = None  # the set value
+    default_value: Optional[DataT] = None  # the default value
     required: bool = False  # True if parameter is required
 
     class Config:


### PR DESCRIPTION
I have resolved two of three `mypy` error bypasses:

1. `CyclingParameter.value` and `CyclingParameter.default_value` are now accurately `Optional` - required redesign of type checking in `technique_widget.py`
2. Redundant `extra` parameter definition in `cycling.py` models have been removed. Definitions are already present in nested `Config` classes

The last `mypy` bypass in `query.py` requires a more intensive refactoring effort to do away with `global` variables. This will be addressed in the near future.