### PR TITLE
Change back to static versioning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,7 @@ title = Aurora
 
 [metadata]
 name = aurora
-version = attr: aurora.__version__
-#version = 0.4.0
+version = 0.6.0
 author = Loris Ercole
 author_email = loris.ercole@epfl.ch
 description = An AiiDAlab application for the Aurora BIG-MAP Stakeholder initiative.


### PR DESCRIPTION
Reverted dynamic versioning in `setup.cfg`. This is necessary due to AiiDAlab's system of pulling an app's version.